### PR TITLE
[ci skip] use bot.inspection = disabled

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,6 @@
 bot:
   automerge: true
-  inspection: false
+  inspection: disabled
 conda_forge_output_validation: true
 github:
   branch_name: main


### PR DESCRIPTION
conda-forge migrates to using "disabled" instead of False as an option for bot.inspection.
https://github.com/regro/cf-scripts/issues/2272#issuecomment-2004119968

@beckermr

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
